### PR TITLE
Add check for duplicated interconnections.

### DIFF
--- a/.github/workflows/run-tox.yml
+++ b/.github/workflows/run-tox.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: [3.7]
+        python: [3.8]
 
     steps:
       - uses: actions/checkout@v2
@@ -34,4 +34,4 @@ jobs:
         run: |
           pip install tox
       - name: Run Tox
-        run: "tox -e pep8,py37"
+        run: "tox -e pep8,py38"

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 dist
 build
 eggs
+.eggs/
 parts
 bin
 var

--- a/.stestr.conf
+++ b/.stestr.conf
@@ -1,0 +1,3 @@
+[DEFAULT]
+test_path=${OS_TEST_PATH:-./networking_interconnection/tests/unit}
+top_dir=./

--- a/networking_interconnection/db/interconnaction_db.py
+++ b/networking_interconnection/db/interconnaction_db.py
@@ -114,7 +114,7 @@ class InterconnectionPluginDb(object):
 
     @db_api.CONTEXT_READER
     def _make_dict(self, db_obj: Interconnection,
-                   fields: typing.Optional[list]=None):
+                   fields: typing.Optional[list] = None):
         res = {
             'id': db_obj['id'],
             'project_id': db_obj['project_id'],
@@ -153,8 +153,8 @@ class InterconnectionPluginDb(object):
 
     @db_api.CONTEXT_READER
     def get_interconnections(self, context,
-                             filters: typing.Optional[dict]=None,
-                             fields: typing.Optional[list]=None):
+                             filters: typing.Optional[dict] = None,
+                             fields: typing.Optional[list] = None):
         db_objs = model_query.get_collection(
             context, Interconnection, None,
             filters=filters, fields=fields)
@@ -169,7 +169,7 @@ class InterconnectionPluginDb(object):
 
     @db_api.CONTEXT_READER
     def get_interconnection(self, context, id: str,
-                            fields: typing.Optional[list]=None):
+                            fields: typing.Optional[list] = None):
         db_obj = self._get_interconnection(context, id)
         return self._make_dict(db_obj, fields)
 

--- a/networking_interconnection/extensions/interconnection.py
+++ b/networking_interconnection/extensions/interconnection.py
@@ -70,6 +70,11 @@ class BgpvpnUsedByAnotherInterconnaction(n_exc.Conflict):
                 "multiple bgpvpns.")
 
 
+class DuplicateInterconnaction(n_exc.Conflict):
+    message = _("Interconnection with local resource %(local_resource_id)s and"
+                " remote resource %(remote_resource_id)s already exist.")
+
+
 class BgpvpnExportTargetsIsEpmty(n_exc.BadRequest):
     message = _("BGPVPN %(bgpvpn)s has not export targets, nothing to use for"
                 " interconnection")

--- a/networking_interconnection/plugins/ml2/plugin.py
+++ b/networking_interconnection/plugins/ml2/plugin.py
@@ -51,6 +51,19 @@ class InterconnectionPlugin(intc_exc.InterconnectionPluginBase,
 
     def create_interconnection(self, context, interconnection):
         data = interconnection[constants.API_RESOURCE_NAME]
+        intcs = self.db.get_interconnections(
+            context,
+            filters={
+                'tenant_id': [data['tenant_id']],
+                'local_resource_id': [data['local_resource_id']],
+                'remote_resource_id': [data['remote_resource_id']]},
+            fields=['id'])
+        # We have to check conflict before changing any statuses because
+        # of that we cannot use database unique key, it's too late
+        if intcs:
+            raise intc_exc.DuplicateInterconnaction(
+                local_resource_id=data['local_resource_id'],
+                remote_resource_id=data['remote_resource_id'])
         if not data['remote_interconnection_id']:
             data['state'] = constants.STATE_WAITING
         else:

--- a/networking_interconnection/plugins/ml2/plugin.py
+++ b/networking_interconnection/plugins/ml2/plugin.py
@@ -198,8 +198,8 @@ class InterconnectionPlugin(intc_exc.InterconnectionPluginBase,
                     body={'bgpvpn': {'import_targets': list(imports)}})
         except n_client_exc.NeutronClientException as err:
             LOG.error('Could not synchronize targets for local resource bgpvpn'
-                      ' with ID %s. Details: request_ids=%s msg=%s'
-                      % (intcn['local_resource_id'], err.request_ids, err))
+                      ' with ID %s. Details: request_ids=%s msg=%s',
+                      (intcn['local_resource_id'], err.request_ids, err))
             if event != events.AFTER_DELETE:
                 self.db.update_interconnection(
                     context, intcn['id'],
@@ -252,10 +252,10 @@ class InterconnectionPlugin(intc_exc.InterconnectionPluginBase,
             remote_neutron, data['remote_interconnection_id'],
             state=constants.STATE_VALIDATING)
         # check local and remote resources
-        if (r_intcn['remote_resource_id'] != data['local_resource_id']
-                or r_intcn['local_resource_id'] != data['remote_resource_id']):
-            LOG.error('Invalid resource settings in remote interconnection %s.'
-                      % (data['remote_interconnection_id']))
+        if (r_intcn['remote_resource_id'] != data['local_resource_id'] or
+                r_intcn['local_resource_id'] != data['remote_resource_id']):
+            LOG.error('Invalid resource settings in remote interconnection %s.',
+                      (data['remote_interconnection_id']))
             raise intc_exc.InvalidRemoteInterconnection()
 
     def _validate_regions(self, data):

--- a/networking_interconnection/tests/unit/plugins/ml2/test_plugin.py
+++ b/networking_interconnection/tests/unit/plugins/ml2/test_plugin.py
@@ -15,8 +15,8 @@
 
 import contextlib
 import copy
-import mock
 import unittest
+from unittest import mock
 import webob.exc
 
 from neutron_lib.plugins import directory
@@ -79,9 +79,9 @@ class BaseTestCaseMixin(test_db_base_plugin_v2.NeutronDbPluginV2TestCase,
                           'TestL3NatServicePlugin'),
         }
 
-        extensions_path = ':'.join(extensions.__path__
-                                   + n_extensions.__path__
-                                   + bgpvpn_ext.__path__)
+        extensions_path = ':'.join(extensions.__path__ +
+                                   n_extensions.__path__ +
+                                   bgpvpn_ext.__path__)
 
         client_mngr = mock.patch(
             'networking_interconnection.common.clients.'
@@ -267,7 +267,7 @@ class TestInterconnectionPlugin(BaseTestCaseMixin):
             with self.intcnt(tenant_id=self.tenant_id_1,
                              local_resource_id=bgpvpn_1['id'],
                              remote_resource_id=bgpvpn_2['id'],
-                             remote_region='RegionTwo') as intcn_1:
+                             remote_region='RegionTwo'):
                 # create duplicate
                 with unittest.TestCase.assertRaises(
                     self, webob.exc.HTTPClientError) as context:

--- a/networking_interconnection/tests/unit/plugins/ml2/test_plugin.py
+++ b/networking_interconnection/tests/unit/plugins/ml2/test_plugin.py
@@ -256,7 +256,7 @@ class TestInterconnectionPlugin(BaseTestCaseMixin):
             for el in self.list('bgpvpn'):
                 self.assertEqual(1, len(el['import_targets']))
 
-    def test_interconnection_duplicate_filed(self):
+    def test_interconnection_duplicate_failed(self):
         with self.bgpvpn(export_targets=['5000:1'],
                          import_targets=['5000:1'],
                          tenant_id=self.tenant_id_1) as bgpvpn_1, \

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -9,6 +9,7 @@ coverage>=3.6
 python-subunit>=0.0.18
 oslosphinx!=3.4.0,>=2.5.0
 oslotest>=1.10.0
+stestr>=1.0.0 # Apache-2.0
 testrepository>=0.0.18
 testscenarios>=0.4
 testtools>=1.4.0

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -2,7 +2,7 @@
 # of appearance. Changing the order has an impact on the overall integration
 # process, which may cause wedges in the gate later.
 
-hacking<0.11,>=0.10.0
+hacking>=6.0.0
 
 mock>=1.2
 coverage>=3.6

--- a/tox.ini
+++ b/tox.ini
@@ -21,7 +21,7 @@ commands =
 
 [testenv:pep8]
 commands =
-  flake8 --max-line-length=120
+  flake8 --max-line-length=80
 
 [testenv:venv]
 commands = {posargs}
@@ -52,7 +52,8 @@ commands = oslopolicy-sample-generator --config-file=etc/oslo-policy-generator/p
 # N534 Untranslated exception message
 # TODO(amotoki) check the following new rules should be fixed or ignored
 # E731 do not assign a lambda expression, use a def
-ignore = E125,E126,E128,E731,H404,H405,N530,N534
+# W504 line break after binary operator
+ignore = E125,E126,E128,E731,H404,H405,N530,N534,W504
 # H106: Don't put vim configuration in source files
 # H203: Use assertIs(Not)None to check for None
 # H204: Use assert(Not)Equal to check for equality

--- a/tox.ini
+++ b/tox.ini
@@ -1,31 +1,39 @@
 [tox]
-envlist = py36
+envlist = py38
 minversion = 1.6
 skipsdist = True
 
 [testenv]
+basepython = python3.8
 usedevelop = True
 install_command = pip install -c {env:UPPER_CONSTRAINTS_FILE:https://raw.githubusercontent.com/sapcc/requirements/{env:OS_SAP_RELEASE}/upper-constraints.txt} -r requirements.txt -r test-requirements.txt -U {opts} {packages}
 setenv = VIRTUAL_ENV={envdir}
          PYTHONWARNINGS=default::DeprecationWarning
          OS_SAP_RELEASE=stable/yoga-m3
 passenv = TRAVIS
-deps = -r{toxinidir}/test-requirements.txt
-       git+https://github.com/sapcc/neutron@{env:OS_SAP_RELEASE}#egg=neutron
+deps = git+https://github.com/sapcc/neutron@{env:OS_SAP_RELEASE}#egg=neutron
        git+https://github.com/sapcc/networking-bgpvpn@{env:OS_SAP_RELEASE}#egg=networking_bgpvpn
+       -e .
 whitelist_externals = sh
-commands = python setup.py testr --slowest --testr-args='{posargs}'
+commands =
+  stestr run {posargs}
+  neutron-db-manage --subproject networking-interconnection --database-connection sqlite:// check_migration
 
 [testenv:pep8]
 commands =
   flake8 --max-line-length=120
-  neutron-db-manage --subproject networking-interconnection check_migration
 
 [testenv:venv]
 commands = {posargs}
 
 [testenv:cover]
-commands = python setup.py testr --coverage --testr-args='{posargs}'
+setenv =
+    PYTHON = coverage run --source networking_interconnection --parallel-mode
+commands =
+    stestr run {posargs}
+    coverage combine
+    coverage html -d cover
+    coverage xml -o cover/coverage.xml
 
 [testenv:genconfig]
 commands = oslo-config-generator --config-file=etc/oslo-config-generator/interconnection.conf


### PR DESCRIPTION
This PR adds a check for interconnections that are created with the same resources (`loca_resource_id` and `remote_resource_id`). Also, this PR updates base [ython version to 3.8 because this version is used for Neutron right now. 